### PR TITLE
Add `interface` value to the Zarf package

### DIFF
--- a/charts/addresspools/templates/l2advertisement-admin-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-admin-ingressgateway.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - admin-ingressgateway
-  {{- if .Values.interface}}
+  {{- if .Values.interface }}
   interfaces:
-    - {{- .Values.interface}}
+    - {{ .Values.interface }}
   {{- end }}
 {{- end }}

--- a/charts/addresspools/templates/l2advertisement-admin-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-admin-ingressgateway.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - admin-ingressgateway
-  {{- if .Values.interface }}
+  {{- if .Values.interface.name }}
   interfaces:
-    - {{ .Values.interface }}
+    - {{ .Values.interface.name }}
   {{- end }}
 {{- end }}

--- a/charts/addresspools/templates/l2advertisement-admin-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-admin-ingressgateway.yaml
@@ -7,4 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - admin-ingressgateway
+  {{- if .Values.interface}}
+  interfaces:
+    - {{- .Values.interface}}
+  {{- end }}
 {{- end }}

--- a/charts/addresspools/templates/l2advertisement-admin-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-admin-ingressgateway.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - admin-ingressgateway
-  {{- if .Values.interface.name }}
+  {{- if .Values.interface }}
   interfaces:
-    - {{ .Values.interface.name }}
+    - {{ .Values.interface }}
   {{- end }}
 {{- end }}

--- a/charts/addresspools/templates/l2advertisement-default.yaml
+++ b/charts/addresspools/templates/l2advertisement-default.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - default
-  {{- if .Values.interface.name }}
+  {{- if .Values.interface }}
   interfaces:
-    - {{ .Values.interface.name }}
+    - {{ .Values.interface }}
   {{- end }}
 {{- end }}

--- a/charts/addresspools/templates/l2advertisement-default.yaml
+++ b/charts/addresspools/templates/l2advertisement-default.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - default
-  {{- if .Values.interface }}
+  {{- if .Values.interface.name }}
   interfaces:
-    - {{ .Values.interface }}
+    - {{ .Values.interface.name }}
   {{- end }}
 {{- end }}

--- a/charts/addresspools/templates/l2advertisement-default.yaml
+++ b/charts/addresspools/templates/l2advertisement-default.yaml
@@ -7,4 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - default
+  {{- if .Values.interface }}
+  interfaces:
+    - {{ .Values.interface }}
+  {{- end }}
 {{- end }}

--- a/charts/addresspools/templates/l2advertisement-passthrough-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-passthrough-ingressgateway.yaml
@@ -7,4 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - keycloak-ingressgateway
+  {{- if .Values.interface }}
+  interfaces:
+    - {{ .Values.interface }}
+  {{- end }}
 {{- end }}

--- a/charts/addresspools/templates/l2advertisement-passthrough-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-passthrough-ingressgateway.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - keycloak-ingressgateway
-  {{- if .Values.interface }}
+  {{- if .Values.interface.name }}
   interfaces:
-    - {{ .Values.interface }}
+    - {{ .Values.interface.name }}
   {{- end }}
 {{- end }}

--- a/charts/addresspools/templates/l2advertisement-passthrough-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-passthrough-ingressgateway.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - keycloak-ingressgateway
-  {{- if .Values.interface.name }}
+  {{- if .Values.interface }}
   interfaces:
-    - {{ .Values.interface.name }}
+    - {{ .Values.interface }}
   {{- end }}
 {{- end }}

--- a/charts/addresspools/templates/l2advertisement-tenant-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-tenant-ingressgateway.yaml
@@ -7,4 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - tenant-ingressgateway
+  {{- if .Values.interface }}
+  interfaces:
+    - {{ .Values.interface }}
+  {{- end }}
 {{- end }}

--- a/charts/addresspools/templates/l2advertisement-tenant-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-tenant-ingressgateway.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - tenant-ingressgateway
-  {{- if .Values.interface.name }}
+  {{- if .Values.interface }}
   interfaces:
-    - {{ .Values.interface.name }}
+    - {{ .Values.interface }}
   {{- end }}
 {{- end }}

--- a/charts/addresspools/templates/l2advertisement-tenant-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-tenant-ingressgateway.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   ipAddressPools:
     - tenant-ingressgateway
-  {{- if .Values.interface }}
+  {{- if .Values.interface.name }}
   interfaces:
-    - {{ .Values.interface }}
+    - {{ .Values.interface.name }}
   {{- end }}
 {{- end }}

--- a/charts/addresspools/tmp-values.yaml
+++ b/charts/addresspools/tmp-values.yaml
@@ -1,4 +1,0 @@
-adminIngress:
-  ipAddressPool: 192.168.1.1
-
-interface: primary0

--- a/charts/addresspools/tmp-values.yaml
+++ b/charts/addresspools/tmp-values.yaml
@@ -1,0 +1,5 @@
+adminIngress:
+  ipAddressPool: 192.168.1.1
+
+interfaces:
+  - primary0

--- a/charts/addresspools/tmp-values.yaml
+++ b/charts/addresspools/tmp-values.yaml
@@ -1,5 +1,4 @@
 adminIngress:
   ipAddressPool: 192.168.1.1
 
-interfaces:
-  - primary0
+interface: primary0

--- a/charts/addresspools/values.yaml
+++ b/charts/addresspools/values.yaml
@@ -23,5 +23,4 @@ passthroughIngress:
   matchLabels:
     app: passthrough-ingressgateway
 
-interface:
-  name: ""
+interface: ""

--- a/charts/addresspools/values.yaml
+++ b/charts/addresspools/values.yaml
@@ -6,19 +6,19 @@ default:
   ipAddressPoolCIDR: ""
 
 adminIngress:
-  ipAddressPool: []
+  ipAddressPool: ""
   namespace: "istio-admin-gateway"
   matchLabels:
     app: admin-ingressgateway
 
 tenantIngress:
-  ipAddressPool: []
+  ipAddressPool: ""
   namespace: "istio-tenant-gateway"
   matchLabels:
     app: tenant-ingressgateway
 
 passthroughIngress:
-  ipAddressPool: []
+  ipAddressPool: ""
   namespace: "istio-passthrough-gateway"
   matchLabels:
     app: passthrough-ingressgateway

--- a/charts/addresspools/values.yaml
+++ b/charts/addresspools/values.yaml
@@ -10,15 +10,17 @@ adminIngress:
   namespace: "istio-admin-gateway"
   matchLabels:
     app: admin-ingressgateway
-    
+
 tenantIngress:
   ipAddressPool: []
   namespace: "istio-tenant-gateway"
   matchLabels:
     app: tenant-ingressgateway
-    
+
 passthroughIngress:
   ipAddressPool: []
   namespace: "istio-passthrough-gateway"
   matchLabels:
     app: passthrough-ingressgateway
+
+interface: ""

--- a/charts/addresspools/values.yaml
+++ b/charts/addresspools/values.yaml
@@ -23,4 +23,5 @@ passthroughIngress:
   matchLabels:
     app: passthrough-ingressgateway
 
-interface: ""
+interface:
+  name: ""

--- a/values/addresspools-values.yaml
+++ b/values/addresspools-values.yaml
@@ -1,11 +1,13 @@
-default: 
+default:
   ipAddressPoolCIDR: "###ZARF_VAR_IP_ADDRESS_POOL###"
 
 adminIngress:
   ipAddressPool: "###ZARF_VAR_IP_ADDRESS_ADMIN_INGRESSGATEWAY###"
 
-tenantIngress: 
+tenantIngress:
   ipAddressPool: "###ZARF_VAR_IP_ADDRESS_TENANT_INGRESSGATEWAY###"
 
-passthroughIngress: 
+passthroughIngress:
   ipAddressPool: "###ZARF_VAR_IP_ADDRESS_KEYCLOAK_INGRESSGATEWAY###"
+
+interface: "###ZARF_VAR_INTERFACE###"

--- a/zarf-config.yaml
+++ b/zarf-config.yaml
@@ -1,3 +1,7 @@
 package:
   create:
     max_package_size: "1000000000"
+
+# deploy:
+#   set:
+#     interface: 'primary0'

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -74,6 +74,6 @@ components:
           - name: IP_ADDRESS_PASSTHROUGH_INGRESSGATEWAY
             path: passthroughIngress.ipAddressPool
           - name: IP_ADDRESS_TENANT_INGRESSGATEWAY
-            path: tenantIngress.ipAddresPool
-        valuesFiles:
-          - values/addresspools-values.yaml
+            path: tenantIngress.ipAddressPool
+        # valuesFiles:
+        #   - values/addresspools-values.yaml

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -66,7 +66,7 @@ components:
         localPath: charts/addresspools
         variables:
           - name: INTERFACE
-            path: interface.name
+            path: interface
           - name: IP_ADDRESS_POOL
             path: default.ipAddressPoolCIDR
           - name: IP_ADDRESS_ADMIN_INGRESSGATEWAY

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -64,5 +64,16 @@ components:
         # x-release-please-end
         namespace: metallb-system
         localPath: charts/addresspools
+        variables:
+          - name: INTERFACE
+            path: interface.name
+          - name: IP_ADDRESS_POOL
+            path: default.ipAddressPoolCIDR
+          - name: IP_ADDRESS_ADMIN_INGRESSGATEWAY
+            path: adminIngress.ipAddressPool
+          - name: IP_ADDRESS_PASSTHROUGH_INGRESSGATEWAY
+            path: passthroughIngress.ipAddressPool
+          - name: IP_ADDRESS_TENANT_INGRESSGATEWAY
+            path: tenantIngress.ipAddresPool
         valuesFiles:
           - values/addresspools-values.yaml

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -24,6 +24,10 @@ variables:
     description: When using this package in concert with UDS Core, the IP address of the tenant-ingressgateway service
     default: ""
     prompt: false
+  - name: INTERFACE
+    description: When using this package in concert with UDS Core, the network interface of the K8s nodes which MetalLB should use
+    default: ""
+    prompt: false
 
 components:
   - name: preflight


### PR DESCRIPTION
In the HNCD context, we need to specify the interface where MetalLB listens.  The default behavior is to listen/advertise on all interfaces.  While possibly not a problem, we feel our setup warrants being explicit about which interface MetalLB listens on for L2 advertisements.

I have tested this package on HNCD hardware and confirmed that it works as expected when passing values for the individual ingress gateways.  @robmcelvenny , I'd like to make sure this works where you need it as well before merging.